### PR TITLE
Updated column default and set all rows to default

### DIFF
--- a/database/migrations/2020_09_03_022200_default_colors.php
+++ b/database/migrations/2020_09_03_022200_default_colors.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DefaultColors extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('company', function (Blueprint $table) {
+            $table->string('colors', 255)->default('000000;FFFFFF;323645;61527E;848896;A48BD5;F6F6F6;FFFFFF;404452;999999;E94038')->change();
+        });
+        DB::raw('UPDATE company set colors = "000000;FFFFFF;323645;61527E;848896;A48BD5;F6F6F6;FFFFFF;404452;999999;E94038"');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('company', function (Blueprint $table) {
+            $table->string('colors', 255)->default('484848;FFFFFF;2A58AD;1D4C9E;82A7EB;FCED16;EAEEF1;FFFFFF;404452;999999')->change();
+        });
+        DB::raw('UPDATE company set colors = "484848;FFFFFF;2A58AD;1D4C9E;82A7EB;FCED16;EAEEF1;FFFFFF;404452;999999"');
+    }
+}


### PR DESCRIPTION
I added a migration to set the column default with the new color set. I also added an update command to add the color set to every record in the table. This should only affect new databases being migrated, so there should only be one record in the table.